### PR TITLE
Added note about starting in a smaller initial build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ This is set in the exp.json file.
   }
 ```
 
+* Keep in mind you may want to start with an earlier initial buildNumber such as 0.0.1, so when you launch you get the coveted 1.0.0
+
 # STEP 3
 
 ### Define a Scheme


### PR DESCRIPTION
Usually when I start with the first buildVersion of 1.0.0 I'm bummed that the real first version that launches, after some failed attempts and internal adhoc distribution, the real first version is 1.0.134 :)